### PR TITLE
fix: add dependency on @babel/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
   },
   "author": "David Bonnet <david@bonnet.cc>",
   "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.11.2"
+  },
   "devDependencies": {
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
-    "@babel/runtime": "^7.11.2",
     "astring": "^1.4.3",
     "ava": "^3.12.1",
     "babel-plugin-module-extension-resolver": "^1.0.0-rc.2",


### PR DESCRIPTION
Move `@babel/runtime` from `devDependencies` to `dependencies` since it's needed for requiring astravel.

Fixes #34